### PR TITLE
Replace / with \ in using modules directives.

### DIFF
--- a/PSCVSS/PSCVSS.psm1
+++ b/PSCVSS/PSCVSS.psm1
@@ -1,6 +1,6 @@
-using module "./PSCVSS/Class/BaseScore.psm1"
-using module "./PSCVSS/Class/EnvironmentalScore.psm1"
-using module "./PSCVSS/Class/TemporalScore.psm1"
+using module ".\Class\BaseScore.psm1"
+using module ".\Class\EnvironmentalScore.psm1"
+using module ".\Class\TemporalScore.psm1"
 
 #Get public and private function definition files.
 $Public  = @( Get-ChildItem -Path $PSScriptRoot\Public\*.ps1 -Recurse -ErrorAction SilentlyContinue )


### PR DESCRIPTION
Relative paths in using module directives aren't treated as relative to the enclosing a script unless they begin with `\`, rather than `/`. Note that `\` works cross platform in PowerShell Core (tested on macOS).

See https://github.com/PowerShell/PowerShell/issues/7424.

Should close #1

Tested locally on macOS Mojave (version 10.14.5) and PowerShell Core v7.0.1.

- ✅Current folder git repository at commit a9af767.
- ✅Precondition: `PSCVSS` module not installed.
- ✅Precondition: `PSCVSS` module cannot be imported.
- ✅Precondition: `Get-CVSSScore` function no found.
- ✅Module published to local package repository from `PSCVSS` subfolder of current folder containing `PSCVSS` git repository.
- ✅Module installs when working directory is not the folder containing the `PSCVSS` git repository.
- ✅Module imports successfully.
- ✅`Get-CVSSScore` runs successfully.

![image](https://user-images.githubusercontent.com/21147592/82861115-928b0200-9f13-11ea-8e8b-3acf69f695ac.png)
