### PR TITLE
Address string parsing bug for getFormattedValue()

### DIFF
--- a/PSCVSS/Class/PSCVSS.Classes.ps1
+++ b/PSCVSS/Class/PSCVSS.Classes.ps1
@@ -105,7 +105,7 @@ class EnvironmentalScore {
 
     [String] getFormattedValue($value){
         $intNumber = ($value).ToString().Split('.')[0]
-        $decNumber = ($value).ToString().Split('.')[1][0]
+        $decNumber = ($value).ToString('n1').Split('.')[1][0]
         return "$intNumber.$decNumber"
     }
 


### PR DESCRIPTION
When a subscore is a whole number, there is no ".0" as part of the $value passed to getFormattedValue(). As a result, line 108 throws a null value exception. Added in the 'n1' string format to ensure there is a ".0" to work with the existing string parsing code.